### PR TITLE
Actualize this starter kit

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["react", "es2015"]
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "start": "nw ./public/",
     "watch": "webpack-dev-server",
+    "build": "webpack --output-path build --optimize-dedupe",
     "test": "standard"
   }
 }

--- a/public/package.json
+++ b/public/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "Git Branch Deleter",
 	"main": "http://localhost:3000",
+    	"node-remote": "localhost",
 	"webkit": {
 		"plugin": true
 	}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,8 +12,7 @@ var config = getConfig({
 	}
 })
 
-// target property not working for node-webkit
-// config.target = 'node-webkit'
+config.target = 'node-webkit'
 
 // Adds new plugin to generated config which exposes underscore.js globally
 config.plugins.push(


### PR DESCRIPTION
 * without .babelrc example code didn't compile
 * webpack target `node-webkit` for accessing `window`
 * `npm run build` with `--optimize-dedupe` in order not to fail on prod build
 * `"node-remote": "localhost"` in nw manifest is for calling "require" on remote pages (`localhost:300`)